### PR TITLE
[Merge] [#5] 앨범 상단UI 만들기

### DIFF
--- a/AppleMusicClone.xcodeproj/project.pbxproj
+++ b/AppleMusicClone.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		DFB8BB7B28773959001F9068 /* MusicSearchCategoryCapsulelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB8BB7A28773958001F9068 /* MusicSearchCategoryCapsulelView.swift */; };
 		DFCA21CF287A73FC0055232E /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFCA21CE287A73FC0055232E /* Category.swift */; };
 		DFCA21D1287AC50D0055232E /* AlbumDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFCA21D0287AC50D0055232E /* AlbumDetailView.swift */; };
+		DFCA21D5287AD61D0055232E /* AlbumDetailUpperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFCA21D4287AD61D0055232E /* AlbumDetailUpperView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +41,7 @@
 		DFB8BB7A28773958001F9068 /* MusicSearchCategoryCapsulelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSearchCategoryCapsulelView.swift; sourceTree = "<group>"; };
 		DFCA21CE287A73FC0055232E /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		DFCA21D0287AC50D0055232E /* AlbumDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetailView.swift; sourceTree = "<group>"; };
+		DFCA21D4287AD61D0055232E /* AlbumDetailUpperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetailUpperView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,6 +113,7 @@
 				DF0C68EE28707FCC0015023E /* ArtistCell.swift */,
 				DFB8BB7A28773958001F9068 /* MusicSearchCategoryCapsulelView.swift */,
 				DFCA21D0287AC50D0055232E /* AlbumDetailView.swift */,
+				DFCA21D4287AD61D0055232E /* AlbumDetailUpperView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -201,6 +204,7 @@
 				DF0234FE286978AD009E9C76 /* AppleMusicCloneApp.swift in Sources */,
 				DFCA21CF287A73FC0055232E /* Category.swift in Sources */,
 				DFCA21D1287AC50D0055232E /* AlbumDetailView.swift in Sources */,
+				DFCA21D5287AD61D0055232E /* AlbumDetailUpperView.swift in Sources */,
 				DF02351528697FB9009E9C76 /* LibraryView.swift in Sources */,
 				DF02351728697FE8009E9C76 /* ListenNowView.swift in Sources */,
 				4A717A332872DB9C00D9D4E9 /* SearchListView.swift in Sources */,

--- a/AppleMusicClone/Models/Category.swift
+++ b/AppleMusicClone/Models/Category.swift
@@ -15,7 +15,7 @@ struct CategoryModel: Identifiable {
 
 extension CategoryModel {
     static var list: [CategoryModel] = [
-        CategoryModel(categoryTitle: "인기 검색 결과", selected: false),
+        CategoryModel(categoryTitle: "인기 검색 결과", selected: true),
         CategoryModel(categoryTitle: "아티스트", selected: false),
         CategoryModel(categoryTitle: "앨범", selected: false),
         CategoryModel(categoryTitle: "노래", selected: false),

--- a/AppleMusicClone/Views/AlbumDetailUpperView.swift
+++ b/AppleMusicClone/Views/AlbumDetailUpperView.swift
@@ -10,45 +10,43 @@ import MusicKit
 
 struct AlbumDetailUpperView: View {
     var album: Album
-    let playButton: [Int: [String]] = [0: ["play.fill", "음악"], 1: ["arrow.left.arrow.right", "임의재생"]]
-    let albumWidth = UIScreen.main.bounds.width / 2 - 30
-    let albumHeight = (UIScreen.main.bounds.width / 2 - 30) / 3 - 10
+    let cornerRadius: CGFloat = 10
+    let playButton: [[String]] = [["play.fill", "재생"], ["arrow.left.arrow.right", "임의재생"]]
+    let descriptionInset = EdgeInsets(top: 0, leading: 25, bottom: 0, trailing: 25)
+    let rectanglePlayButtonWidth = UIScreen.main.bounds.width * 0.5 - 30
+    let rectanglePlayButtonHeight = (UIScreen.main.bounds.width * 0.5 - 30) * 0.33 - 10
+    let stackSpacing: CGFloat = 5
     
     var body: some View {
-        VStack(alignment: .center, spacing: 5) {
-            ZStack {
-                Rectangle()
-                    .frame(width: 250, height: 250)
-                    .cornerRadius(10)
-                    .shadow(radius: 5)
+        VStack(alignment: .center, spacing: stackSpacing) {
                 if let artwork = album.artwork {
                     ArtworkImage(artwork, width: 250, height: 250)
-                        .cornerRadius(10)
+                        .cornerRadius(cornerRadius)
+                        .shadow(radius: cornerRadius * 0.5)
                 }
-            }
-            VStack(spacing: 5) {
+            VStack(spacing: stackSpacing) {
                 Text(album.title)
                     .font(.headline)
                     .bold()
                 Text(album.artistName)
                     .foregroundColor(.accentColor)
             }
-            .padding(EdgeInsets(top: 0, leading: 25, bottom: 0, trailing: 25))
+            .padding(descriptionInset)
             Text("\(album.genreNames.first ?? "") · \(returnYear(date: album.releaseDate ?? Date()))년")
                 .font(.footnote)
                 .foregroundColor(.secondary)
             HStack {
-                ForEach(playButton.sorted { $0.key < $1.key }, id: \.key){ button in
+                ForEach(playButton, id: \.self){ button in
                     Button(action: {}, label: {
                         ZStack {
                             Rectangle()
-                                .frame(width: albumWidth, height: albumHeight)
-                                .cornerRadius(10)
+                                .frame(width: rectanglePlayButtonWidth, height: rectanglePlayButtonHeight)
+                                .cornerRadius(cornerRadius)
                                 .foregroundColor(Color(.darkGray))
                                 .opacity(0.4)
                             HStack {
-                                Image(systemName: "\(button.value.first ?? "")")
-                                Text(button.value.last ?? "")
+                                Image(systemName: "\(button.first ?? "")")
+                                Text(button.last ?? "")
                             }
                         }
                     })
@@ -56,14 +54,14 @@ struct AlbumDetailUpperView: View {
             }
         }
         .toolbar(content: {
-            HStack {
+            ToolbarItemGroup(placement: .navigationBarTrailing, content: {
                 Button(action: {}, label: {
-                    Image(systemName: "arrow.down.circle")
+                    Image(systemName: "plus")
                 })
                 Button(action: {}, label: {
-                    Image(systemName: "ellipsis.circle")
+                    Image(systemName: "ellipsis")
                 })
-            }
+            })
         })
     }
     

--- a/AppleMusicClone/Views/AlbumDetailUpperView.swift
+++ b/AppleMusicClone/Views/AlbumDetailUpperView.swift
@@ -21,8 +21,10 @@ struct AlbumDetailUpperView: View {
                     .frame(width: 250, height: 250)
                     .cornerRadius(10)
                     .shadow(radius: 5)
-                ArtworkImage(album.artwork!, width: 250, height: 250)
-                    .cornerRadius(10)
+                if let artwork = album.artwork {
+                    ArtworkImage(artwork, width: 250, height: 250)
+                        .cornerRadius(10)
+                }
             }
             VStack(spacing: 5) {
                 Text(album.title)

--- a/AppleMusicClone/Views/AlbumDetailUpperView.swift
+++ b/AppleMusicClone/Views/AlbumDetailUpperView.swift
@@ -1,0 +1,74 @@
+//
+//  AlbumDetailUpperView.swift
+//  AppleMusicClone
+//
+//  Created by 박성수 on 2022/07/10.
+//
+
+import SwiftUI
+import MusicKit
+
+struct AlbumDetailUpperView: View {
+    var album: Album
+    let playButton: [Int: [String]] = [0: ["play.fill", "음악"], 1: ["arrow.left.arrow.right", "임의재생"]]
+    let albumWidth = UIScreen.main.bounds.width / 2 - 30
+    let albumHeight = (UIScreen.main.bounds.width / 2 - 30) / 3 - 10
+    
+    var body: some View {
+        VStack(alignment: .center, spacing: 5) {
+            ZStack {
+                Rectangle()
+                    .frame(width: 250, height: 250)
+                    .cornerRadius(10)
+                    .shadow(radius: 5)
+                ArtworkImage(album.artwork!, width: 250, height: 250)
+                    .cornerRadius(10)
+            }
+            VStack(spacing: 5) {
+                Text(album.title)
+                    .font(.headline)
+                    .bold()
+                Text(album.artistName)
+                    .foregroundColor(.accentColor)
+            }
+            .padding(EdgeInsets(top: 0, leading: 25, bottom: 0, trailing: 25))
+            Text("\(album.genreNames.first ?? "") · \(returnYear(date: album.releaseDate ?? Date()))년")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+            HStack {
+                ForEach(playButton.sorted { $0.key < $1.key }, id: \.key){ button in
+                    Button(action: {}, label: {
+                        ZStack {
+                            Rectangle()
+                                .frame(width: albumWidth, height: albumHeight)
+                                .cornerRadius(10)
+                                .foregroundColor(Color(.darkGray))
+                                .opacity(0.4)
+                            HStack {
+                                Image(systemName: "\(button.value.first ?? "")")
+                                Text(button.value.last ?? "")
+                            }
+                        }
+                    })
+                }
+            }
+        }
+        .toolbar(content: {
+            HStack {
+                Button(action: {}, label: {
+                    Image(systemName: "arrow.down.circle")
+                })
+                Button(action: {}, label: {
+                    Image(systemName: "ellipsis.circle")
+                })
+            }
+        })
+    }
+    
+    private func returnYear(date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy"
+        let year = dateFormatter.string(from: date)
+        return year
+    }
+}

--- a/AppleMusicClone/Views/AlbumDetailView.swift
+++ b/AppleMusicClone/Views/AlbumDetailView.swift
@@ -12,6 +12,7 @@ struct AlbumDetailView: View {
     var album: Album
     
     var body: some View {
+        AlbumDetailUpperView(album: album)
         Text(album.title)
     }
 }

--- a/AppleMusicClone/Views/ArtistCell.swift
+++ b/AppleMusicClone/Views/ArtistCell.swift
@@ -16,6 +16,7 @@ struct ArtistCell: View {
             HStack {
                 if let artwork = album.artwork {
                     ArtworkImage(artwork, width: 50)
+                        .cornerRadius(5)
                 } else {
                     Image(systemName: "square.stack")
                         .resizable()
@@ -33,7 +34,6 @@ struct ArtistCell: View {
                         .foregroundColor(.secondary)
                 }
                 Spacer()
-                Image(systemName: "chevron.right")
             }
         }
         .padding(.init(top: 5, leading: 0, bottom: 5, trailing: 0))


### PR DESCRIPTION
### 작업내용
앨범 디테일뷰의 상단부분 UI를 만들었습니다.

<img src="https://user-images.githubusercontent.com/72736657/178240893-431d7615-aab7-49db-b5cf-d41b6591a9e2.jpg" width="400" height="550"/>

### 리뷰포인트
'ForEach' 부분에서 딕셔너리의 key값이 의미 있는 값으로 넣어져 있는게 아닙니다. 이런 경우에 더 좋은 방법은 어떤게 있을까요?
> key값을 0, 1 로 둔 이유는 추가로 버튼이 더 생긴다면,  sorted()함수로 순서대로 배치를 할 수 있을 것이라 생각했기 때문입니다.


### 질문
- 부족한 UI가 있는지, 중복되는 코드를 줄일 수 있는 방법은 무엇인지 궁금합니다.
- 숫자로 이미지 크기, 프레임 등이 표기되어 있는데, 더 좋은 방법이 궁금합니다.
  - 숫자가 필요하다면 변수로 두는 편이 좋을까요??
